### PR TITLE
Issues/5 gh action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build & Test
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build solution
+      run: dotnet build --configuration Release --no-restore
+    - name: Execute unit tests
+      run: dotnet test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Build & Release to NuGet
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.301
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build solution
+        run: dotnet build --configuration Release --no-restore
+      - name: Execute unit tests
+        run: dotnet test
+      - name: Publish NuGet
+        uses: brandedoutcast/publish-nuget@v2.5.5
+        with:
+          PROJECT_FILE_PATH: HttpBinding/HttpBinding.csproj
+          NUGET_KEY: ${{secrets.NUGET_KEY}}


### PR DESCRIPTION
#8 Solved

Add GH Action to publish shizzle to NuGet

- Added two workflows
   - When creating a pull request to build & run unit tests
   - When push to master build, test & release

Please create an API Key on NuGet and paste that key as a secret in your repository with the name 'NUGET_KEY'
